### PR TITLE
feat: get json response message on failed HTTP request in HealthReportCommand

### DIFF
--- a/src/PimcoreMonitorBundle/Command/HealthReportCommand.php
+++ b/src/PimcoreMonitorBundle/Command/HealthReportCommand.php
@@ -118,8 +118,11 @@ class HealthReportCommand extends Command
             RedirectionExceptionInterface |
             ServerExceptionInterface $e
         ) {
+            $jsonResponse = json_decode($response->getContent(false), true);
+
             $output->writeln(
-                \sprintf('<error>Sending the data to the endpoint failed!</error> – %s', $e->getMessage())
+                \sprintf('<error>Sending the data to the endpoint failed!</error> – %s – %s',
+                    $jsonResponse['message'], $e->getMessage())
             );
 
             return Command::FAILURE;

--- a/src/PimcoreMonitorBundle/Command/HealthReportCommand.php
+++ b/src/PimcoreMonitorBundle/Command/HealthReportCommand.php
@@ -118,7 +118,7 @@ class HealthReportCommand extends Command
             RedirectionExceptionInterface |
             ServerExceptionInterface $e
         ) {
-            $jsonResponse = json_decode($response->getContent(false), true);
+            $jsonResponse = \json_decode($response->getContent(false), true);
 
             $output->writeln(
                 \sprintf('<error>Sending the data to the endpoint failed!</error> – %s – %s',

--- a/src/PimcoreMonitorBundle/Command/HealthReportCommand.php
+++ b/src/PimcoreMonitorBundle/Command/HealthReportCommand.php
@@ -121,8 +121,11 @@ class HealthReportCommand extends Command
             $jsonResponse = \json_decode($response->getContent(false), true);
 
             $output->writeln(
-                \sprintf('<error>Sending the data to the endpoint failed!</error> – %s – %s',
-                    $jsonResponse['message'], $e->getMessage())
+                \sprintf(
+                    '<error>Sending the data to the endpoint failed!</error> – %s – %s',
+                    $jsonResponse['message'],
+                    $e->getMessage()
+                )
             );
 
             return Command::FAILURE;


### PR DESCRIPTION
This PR adds the JSON response message on failed HTTP requests inside the HealthReportCommand.
This also resolves following issue: https://github.com/w-vision/portal.w-vision.ch/issues/2

Current error message (e.g.):
`Sending the data to the endpoint failed! – HTTP/2 401  returned for "https://portal.w-vision.ch/_monitor/health-report".`

Error message with this PR (e.g.):
`Sending the data to the endpoint failed! – Access denied: No API key available. – HTTP/2 401  returned for "https://portal.w-vision.ch/_monitor/health-report".`